### PR TITLE
Fix theme accents, visitor badge, map sizing, and mobile nav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ atom_feed:
 analytics:
   provider               : false
 
-# Public hit/visitor badge in footer (seeyoufarm; counts https://klyshko.github.io)
+# Public hit/visitor badge in footer (hitscounter.dev; counts https://klyshko.github.io)
 visitor_hits: true
 
 # Site Author

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,11 +1,11 @@
 {% if site.visitor_hits != false %}
 <div class="page__footer-visitor" aria-label="Site traffic">
-  <a href="https://hits.seeyoufarm.com" rel="noopener nofollow" class="page__footer-visitor__badge" title="All-time page views (seeyoufarm hit counter)">
+  <a href="https://hitscounter.dev" rel="noopener nofollow" class="page__footer-visitor__badge" title="Visit counts (today / total); hitscounter.dev">
     <img
-      src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fklyshko.github.io&count_bg=%23132d56&title_bg=%230e2240&title=visitors&icon=&icon_color=%23E7E7E7&edge_flat=false"
-      width="100"
+      src="https://hitscounter.dev/api/hit?url=https%3A%2F%2Fklyshko.github.io&label=visitors&icon=github&color=%23132d56"
+      width="103"
       height="20"
-      alt="Site visitor count (badge)"
+      alt="Site visit counts (badge)"
     />
   </a>
 </div>

--- a/_includes/presentations-map.html
+++ b/_includes/presentations-map.html
@@ -66,8 +66,20 @@
     cm.on('click', function() { window.location.assign(p.url); });
     bounds.push([p.lat, p.lon]);
   });
-  if (bounds.length) {
-    map.fitBounds(bounds, { padding: [40, 40], maxZoom: 4 });
+  function fitOrInvalidate() {
+    try {
+      map.invalidateSize();
+      if (bounds.length) {
+        map.fitBounds(bounds, { padding: [40, 40], maxZoom: 4 });
+      }
+    } catch (err) {}
   }
+  map.whenReady(function() {
+    requestAnimationFrame(function() {
+      fitOrInvalidate();
+      requestAnimationFrame(fitOrInvalidate);
+    });
+  });
+  window.addEventListener('load', fitOrInvalidate);
 })();
 </script>

--- a/_sass/_iso-style.scss
+++ b/_sass/_iso-style.scss
@@ -159,7 +159,7 @@ a::after {
 .page__content a:not(.iso-btn):not(.iso-section__links a):not(.iso-contact__links a) {
   color: var(--iso-accent) !important;
   text-decoration: underline !important;
-  text-decoration-color: rgba(13, 148, 136, 0.3) !important;
+  text-decoration-color: rgba(19, 45, 86, 0.35) !important;
   text-underline-offset: 3px !important;
   background: none !important;
   background-size: unset !important;
@@ -327,7 +327,7 @@ a::after {
 }
 
 /* Greedy overflow toggle: hidden; mobile menu uses .site-nav__burger instead */
-$site-nav-mobile-max: 640px;
+$site-nav-mobile-max: 768px;
 
 .greedy-nav__toggle {
   display: none !important;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -68,7 +68,7 @@ $dark-text-color            : #e0e0e0;
 $dark-border-color          : #333;
 $dark-code-background       : #2d2d2d;
 
-$primary-color              : #7a8288;
+$primary-color              : #132d56;
 $success-color              : #62c462;
 $warning-color              : #f89406;
 $danger-color               : #ee5f5b;
@@ -98,12 +98,12 @@ $youtube-color              : #bb0000;
 $xing-color                 : #006567;
 
 
-/* links */
-$link-color                 : mix($info-color2, $info-color, 50%);
-$link-color-hover           : mix(#000, $link-color, 25%);
-$link-color-visited         : mix(#fff, $link-color, 25%);
+/* links (navy; iso-style overrides many, but defaults survive in some components) */
+$link-color                 : #132d56;
+$link-color-hover           : #0e2240;
+$link-color-visited         : mix(#fff, $link-color, 20%);
 $masthead-link-color        : $primary-color;
-$masthead-link-color-hover  : mix(#000, $primary-color, 25%);
+$masthead-link-color-hover  : $link-color-hover;
 
 
 /*

--- a/assets/js/plugins/jquery.greedy-navigation.js
+++ b/assets/js/plugins/jquery.greedy-navigation.js
@@ -6,7 +6,7 @@
 */
 
 var $nav = $('#site-nav');
-var $btn = $('#site-nav button');
+var $btn = $('#site-nav .greedy-nav__toggle');
 var $vlinks = $('#site-nav .visible-links');
 var $hlinks = $('#site-nav .hidden-links');
 

--- a/assets/js/site-nav.js
+++ b/assets/js/site-nav.js
@@ -1,5 +1,5 @@
 (function () {
-  var MOBILE_MAX = 640;
+  var MOBILE_MAX = 768;
   var nav = document.getElementById("site-nav");
   var burger = document.getElementById("site-nav-burger");
   if (!nav || !burger) return;


### PR DESCRIPTION
- Switch visitor counter to hitscounter.dev (seeyoufarm unavailable)
- Align link and primary SCSS variables with navy accent; fix teal underline
- Leaflet: invalidateSize after layout for reliable map render
- Mobile nav breakpoint 768px; greedy nav targets overflow toggle only
- Refresh config comment for visitor badge